### PR TITLE
Fixed doubled notification issue

### DIFF
--- a/server/services/comments/comments.hooks.js
+++ b/server/services/comments/comments.hooks.js
@@ -120,10 +120,10 @@ module.exports = {
       createNotifications()
     ],
     update: [
-      createMentionNotifications()
+      // createMentionNotifications()
     ],
     patch: [
-      createMentionNotifications()
+      // createMentionNotifications()
     ],
     remove: []
   },

--- a/server/services/contributions/contributions.hooks.js
+++ b/server/services/contributions/contributions.hooks.js
@@ -225,11 +225,11 @@ module.exports = {
       thumbnails(thumbs)
     ],
     update: [
-      createMentionNotifications(),
+      // createMentionNotifications(),
       thumbnails(thumbs)
     ],
     patch: [
-      createMentionNotifications(),
+      // createMentionNotifications(),
       thumbnails(thumbs)
     ],
     remove: [


### PR DESCRIPTION
This commit fixed the issue where up-voting or editing an comment leads to sending the mention notification again. See #106 