### PR TITLE
Make public folder a container internal volume

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,5 +10,6 @@ services:
     volumes:
       - .:/API
       - /API/node_modules
+      - /API/public/ # avoid change of owner
     command: yarn run dev
     tty: true


### PR DESCRIPTION
I couldn't seed the database without the docker environment. Now I found
out I had to `chown -R robert.` and some uploads in public/ folder
were changed. I believe, we can fix this issue for other people, too.