### PR TITLE
[WIP] Fix 404 on removing a comment

### DIFF
--- a/server/services/comments/comments.hooks.js
+++ b/server/services/comments/comments.hooks.js
@@ -105,9 +105,15 @@ module.exports = {
       })
     ],
     remove: [
-      authenticate('jwt'),
-      unless(isProvider('server'),
-        unless(isModerator(),
+      iff(isProvider('server'),
+        softDelete(),
+        authenticate('jwt')
+      ).else( // isProvider == false
+        iff(isModerator(),
+          softDelete(),
+          authenticate('jwt')
+        ).else( // isModerator == false
+          authenticate('jwt'),
           isVerified(),
           restrictToOwner(),
           softDelete()

--- a/server/services/comments/comments.hooks.js
+++ b/server/services/comments/comments.hooks.js
@@ -37,10 +37,10 @@ const xssFields = ['content', 'contentExcerpt'];
 module.exports = {
   before: {
     all: [
-      softDelete(),
       xss({ fields: xssFields })
     ],
     find: [
+      softDelete(),
       // We want to deleted comments to show up
       iff(
         hook => hook.params.headers && hook.params.headers.authorization,
@@ -52,12 +52,14 @@ module.exports = {
       }
     ],
     get: [
+      softDelete(),
       iff(
         hook => hook.params.headers && hook.params.headers.authorization,
         authenticate('jwt')
       )
     ],
     create: [
+      softDelete(),
       authenticate('jwt'),
       // Allow seeder to seed comments
       unless(isProvider('server'),
@@ -67,6 +69,7 @@ module.exports = {
       createExcerpt({ length: 180 })
     ],
     update: [
+      softDelete(),
       authenticate('jwt'),
       unless(isProvider('server'),
         isVerified(),
@@ -76,6 +79,7 @@ module.exports = {
       setNow('updatedAt')
     ],
     patch: [
+      softDelete(),
       authenticate('jwt'),
       unless(isProvider('server'),
         isVerified(),
@@ -105,7 +109,8 @@ module.exports = {
       unless(isProvider('server'),
         unless(isModerator(),
           isVerified(),
-          restrictToOwner()
+          restrictToOwner(),
+          softDelete()
         )
       )
     ]


### PR DESCRIPTION
At the moment, the API returns 404 when deleting a comment. This prevents implementation of https://github.com/Human-Connection/WebApp/pull/347 .

It turns out the issue lies in the before all hook `softDelete`, which seems to be somewhat incompatible or rather order sensitive with the `restrictToOwner` hook.

https://github.com/feathers-plus/feathers-hooks-common/issues/185

I don't have enough experience with feathersjs, but it seems this error can be mitigated by changing the hook order when `restrictToOwner` is used, without sacrificing functionality.

What are your thoughts on that? @roschaefer @appinteractive 